### PR TITLE
meson.build: Fix iconv and boost dependencies

### DIFF
--- a/src/lib/dbus/meson.build
+++ b/src/lib/dbus/meson.build
@@ -25,6 +25,7 @@ dbus = static_library(
   include_directories: inc,
   dependencies: [
     dbus_dep,
+    boost_dep
   ],
 )
 

--- a/src/lib/icu/meson.build
+++ b/src/lib/icu/meson.build
@@ -18,11 +18,22 @@ if icu_dep.found()
     'Init.cxx',
   ]
 elif not get_option('iconv').disabled()
-  have_iconv = compiler.has_function('iconv')
-  conf.set('HAVE_ICONV', have_iconv)
-  if get_option('iconv').enabled()
-    error('iconv() not available')
+  # Empty dependency.
+  icu_dep = dependency('', required: false)
+  if not compiler.has_function(
+      'iconv',
+      prefix: '#include <iconv.h>'
+    )
+    icu_dep = compiler.find_library('iconv')
+    if not compiler.has_function(
+        'iconv',
+        prefix: '#include <iconv.h>',
+        dependencies: [icu_dep]
+      )
+      error('iconv() not available')
+    endif
   endif
+  conf.set('HAVE_ICONV', true)
 endif
 
 icu = static_library(
@@ -30,8 +41,8 @@ icu = static_library(
   icu_sources,
   include_directories: inc,
   dependencies: [
-    icu_dep,
-  ],
+    icu_dep
+  ]
 )
 
 icu_dep = declare_dependency(


### PR DESCRIPTION
Scans for built-in and library-provided iconv().

Adds boost dependencies, where required for compilation.